### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/media_etl/db/spotify.py
+++ b/media_etl/db/spotify.py
@@ -6,7 +6,7 @@ import sys
 import configparser
 import traceback
 import spotipy
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from spotipy.oauth2 import SpotifyClientCredentials
 
 BASE_DIR, SCRIPT_NAME = os.path.split(os.path.abspath(__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ pathvalidate>=0.29.1,<2.4.0
 psycopg2-binary>=2.8.5,<2.9.0
 pandas>=0.24.2,<1.1.0
 spotipy>=2.12.0,<2.13.0
-fuzzywuzzy>=0.18.0,<0.20.0
-python-Levenshtein>=0.12.0,<0.15.0
+rapidfuzz>=0.9.1,<0.10.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy